### PR TITLE
1.8.0 update

### DIFF
--- a/newt/CHANGELOG.md
+++ b/newt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 🔹 Version 1.8.0 - (23.12.2025)
+- Updated newt version to 1.8.0 to support the new Pangolin update
+- Port firewalling for Private Resources by @oschwartz10612 in #203
+- Support ICMP test requests for clients by @oschwartz10612 in #208
+- fix(nix): use correct hash for vendored deps by @water-sucks in #199
+- feat(build): parallelize go-build-release and github actions with matrix by @water-sucks in #200
+
 ## 🔹 Version 1.7.0 - (12.12.2025)
 - Updated newt version to 1.7.0 to support the new Pangolin update
 

--- a/newt/Dockerfile
+++ b/newt/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/hassio-addons/base:14.0.0
 
 # Define the Newt version (used everywhere below)
-ARG NEWT_VERSION=1.7.0
+ARG NEWT_VERSION=1.8.0
 ENV NEWT_VERSION=${NEWT_VERSION}
 
 # Install dependencies

--- a/newt/config.yaml
+++ b/newt/config.yaml
@@ -1,5 +1,5 @@
 name: "Newt Add-on"
-version: "1.7.0"
+version: "1.8.0"
 slug: "newt"
 description: "Runs Newt inside Home Assistant OS"
 icon: "icon.png"


### PR DESCRIPTION
## 🔹 Version 1.8.0 - (23.12.2025)
- Updated newt version to 1.8.0 to support the new Pangolin update
- Port firewalling for Private Resources by @oschwartz10612 in #203
- Support ICMP test requests for clients by @oschwartz10612 in #208
- fix(nix): use correct hash for vendored deps by @water-sucks in #199
- feat(build): parallelize go-build-release and github actions with matrix by @water-sucks in #200